### PR TITLE
⚡ principio de responsabilidad única en Alertas

### DIFF
--- a/src/alerts/alerts.module.ts
+++ b/src/alerts/alerts.module.ts
@@ -3,12 +3,15 @@ import { Module } from "@nestjs/common"
 import { AlertsService } from "./alerts.service"
 import { AlertsController } from "./alerts.controller"
 import { PrismaModule } from "src/prisma/prisma.module"
+
+import { AlertsRepository } from "./repository/alerts.repository"
 import { MailModule } from "src/mail/mail/mail.module"
 
 @Module({
   imports: [PrismaModule, MailModule],
   controllers: [AlertsController],
-  providers: [AlertsService],
+  providers: [AlertsService, AlertsRepository],
+  exports: [AlertsService],
 })
 export class AlertsModule {}
 

--- a/src/alerts/repository/alerts.repository.ts
+++ b/src/alerts/repository/alerts.repository.ts
@@ -1,0 +1,188 @@
+import { Injectable } from "@nestjs/common";
+import { PrismaService } from "../../prisma/prisma.service";
+import { CreateAlertDto } from "../dto/create-alert.dto";
+import { UpdateAlertDto } from "../dto/update-alert.dto";
+import { AlertStatus } from "../dto/update-status.dto";
+
+
+@Injectable()
+export class AlertsRepository {
+  constructor(private prisma: PrismaService) {}
+
+  // Métodos para alertas
+  async createAlert(createAlertDto: CreateAlertDto) {
+    return this.prisma.alerts.create({
+      data: {
+        ...createAlertDto,
+        fecha: new Date(),
+        send: createAlertDto.send ?? false,
+        estado: AlertStatus.PENDIENTE,
+      },
+      include: {
+        box: {
+          include: {
+            supplier: true,
+          },
+        },
+      },
+    });
+  }
+
+  async findAllAlerts() {
+    return this.prisma.alerts.findMany({
+      include: {
+        box: {
+          include: {
+            supplier: true,
+          },
+        },
+        gestor: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: {
+        fecha: "desc",
+      },
+    });
+  }
+
+  async findAlertById(id: number) {
+    return this.prisma.alerts.findUnique({
+      where: { id },
+      include: {
+        box: {
+          include: {
+            supplier: true,
+          },
+        },
+        gestor: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+  }
+
+  async updateAlert(id: number, updateAlertDto: UpdateAlertDto) {
+    return this.prisma.alerts.update({
+      where: { id },
+      data: updateAlertDto,
+    });
+  }
+
+  async deleteAlert(id: number) {
+    return this.prisma.alerts.delete({
+      where: { id },
+    });
+  }
+
+  async markAlertAsSent(id: number) {
+    return this.prisma.alerts.update({
+      where: { id },
+      data: {
+        send: true,
+        email_enviado: new Date(),
+      },
+    });
+  }
+
+  async findAlertsByBox(boxId: number) {
+    return this.prisma.alerts.findMany({
+      where: { caja_id: boxId },
+      include: {
+        gestor: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: {
+        fecha: "desc",
+      },
+    });
+  }
+
+  async findPendingAlerts() {
+    return this.prisma.alerts.findMany({
+      where: {
+        send: false,
+        estado: AlertStatus.PENDIENTE,
+      },
+      include: {
+        box: {
+          include: {
+            supplier: true,
+          },
+        },
+      },
+      orderBy: {
+        fecha: "desc",
+      },
+    });
+  }
+
+  async findAlertsByStatus(estado: AlertStatus) {
+    return this.prisma.alerts.findMany({
+      where: { estado },
+      include: {
+        box: {
+          include: {
+            supplier: true,
+          },
+        },
+        gestor: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: {
+        fecha: "desc",
+      },
+    });
+  }
+
+  async updateAlertStatus(id: number, updateData: any) {
+    return this.prisma.alerts.update({
+      where: { id },
+      data: updateData,
+      include: {
+        box: true,
+        gestor: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+  }
+
+  // Métodos para otras entidades relacionadas
+  async findBoxById(boxId: number) {
+    return this.prisma.box.findUnique({
+      where: { id: boxId },
+      include: {
+        supplier: true,
+      },
+    });
+  }
+
+  async findUserById(userId: number) {
+    return this.prisma.users.findUnique({
+      where: { id: userId },
+    });
+  }
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,14 +1,19 @@
 /* eslint-disable prettier/prettier */
-import { Controller, Get, Post, Body, Patch, Param, Delete, ParseIntPipe } from "@nestjs/common"
+import { Controller, Get, Post, Body, Patch, Param, Delete, ParseIntPipe, UseGuards } from "@nestjs/common"
 import  { UsersService } from "./users.service"
 import  { CreateUserDto } from "./dto/create-user.dto"
 import { UpdateUserDto } from "./dto/update-user.dto"
+import { Roles } from "src/auth/decorators/roles.decorator";
+import { JwtAuthGuard } from "src/auth/guards/jwt-auth.guard";
+import { RolesGuard } from "src/auth/guards/roles.guard";
 
 @Controller("users")
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)//guard para verificar que está autenticado
+  @Roles(1) // Solo administradores (idRol = 1)
   create(@Body() createUserDto: CreateUserDto) {
     return this.usersService.create(createUserDto);
   }


### PR DESCRIPTION
Implemente el patrón de responsabilidad única para el módulo de alertas, separando las responsabilidades entre el acceso a datos y la lógica de negocio. Se ha creado un repositorio dedicado para las operaciones de base de datos, mientras que el servicio ahora se enfoca exclusivamente en la lógica de negocio y el manejo de errores.

Cambios Realizados

**Creación de AlertsRepository**:

1. Nuevo archivo `src/alerts/repositories/alerts.repository.ts` que encapsula todas las operaciones de base de datos
2. Métodos específicos para cada operación CRUD y consultas personalizadas

**Refactorización de AlertsService**:

1. Modificación del servicio para utilizar el nuevo repositorio
2. Centralización del manejo de errores y excepciones en el servicio
3. Implementación de validaciones consistentes para casos donde no existen datos
4. Manejo específico de `NotFoundException` para diferentes escenarios

#NotFoundException:
Se utiliza para indicar que un recurso solicitado no fue encontrado (error HTTP 404).
Cuando se lanza, NestJS automáticamente devuelve una respuesta HTTP con:  Status Code: 404
{
  "statusCode": 404,
  "message": "No existen alertas",
  "error": "Not Found"
}

## Beneficios

- **Separación de Responsabilidades**: Clara distinción entre acceso a datos (repositorio) y lógica de negocio (servicio)
- **Código más Mantenible**: Facilita la comprensión y el mantenimiento del código al tener responsabilidades bien definidas
- **Mejora en Testabilidad**: Permite crear mocks del repositorio para pruebas unitarias del servicio
- **Manejo Consistente de Errores**: Centralización del manejo de errores en el servicio con mensajes específicos para cada caso
- **Flexibilidad para Cambios**: Facilita futuros cambios en la capa de persistencia sin afectar la lógica de negocio


## Manejo de Casos de Error
Implemente mensajes de error específicos para diferentes escenarios:

- "No existen alertas" cuando no hay alertas en el sistema
- "No existen alertas pendientes" cuando no hay alertas en estado pendiente
- "No existen alertas con estado X" cuando se buscan alertas por estado
- "No existen alertas para la caja con ID X" cuando se buscan alertas por caja